### PR TITLE
Update miner.go

### DIFF
--- a/miner.go
+++ b/miner.go
@@ -1,3 +1,4 @@
+
 package main
 
 import (
@@ -236,6 +237,7 @@ func main() {
 
 	for i:=0;i<x;i++{
 		go workers(username, password,addr)
+		time.Sleep(1*time.Second)
 	}
 	
 	go func(){
@@ -250,4 +252,3 @@ func main() {
 		calcHash()
 	}
 }
-


### PR DESCRIPTION
Added time.Sleep between workers' creation. Because with higher workers count ngrok was closing the connection on start. This prevents it, however it also increases startup time.